### PR TITLE
Add support for tooltips

### DIFF
--- a/src/DeckGL.purs
+++ b/src/DeckGL.purs
@@ -39,6 +39,7 @@ type MapPropsR r =
   , onClick :: EffectFn2 (Nullable LayerInfo) MouseEvent Unit
   , onHover :: EffectFn2 (Nullable LayerInfo) MouseEvent Unit
   , viewState :: Record (ViewportR ())
+  , getTooltip :: LayerInfo -> Nullable String
   | r
   )
 


### PR DESCRIPTION
`Deck` from `@deck.gl/core` actually contains more functions than we expose to the purescript-side. This PR specifically adds the `getToolTip` callback, see: https://deck.gl/docs/api-reference/core/deck#gettooltip

We could consider adding _all_ of the exposed functions, but this PR doesn't attempt to do so.